### PR TITLE
スプレッド演算子で展開されたプロパティのサポート状態の表示を修正

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -96,11 +96,10 @@ export default function Home() {
             .
           </p>
           <p className="text-sm sm:text-base mb-4">
-            Currently, only support direct inline props properly, and cases
-            using the spread operator are{" "}
-            <span className="text-red-500">not</span> supported. Even if they
-            are actually supported in L2, they are still counted as unsupported
-            properties.
+            Now supports both direct inline props and cases using the spread operator.
+            Previously, cases using the spread operator were
+            erroneously counted as unsupported properties, but this issue has been
+            resolved.
           </p>
           <div className="flex flex-col sm:flex-row justify-center items-start gap-4">
             <div className="flex-1 p-4 bg-gray-800 rounded-lg">
@@ -117,8 +116,8 @@ export default function Home() {
               </pre>
             </div>
             <div className="flex-1 p-4 bg-gray-800 rounded-lg">
-              <h2 className="text-base sm:text-lg font-bold text-red-400 mb-2">
-                Spread operator Props (false positive)
+              <h2 className="text-base sm:text-lg font-bold text-green-400 mb-2">
+                Spread operator Props (now supported)
               </h2>
               <pre className="whitespace-pre-wrap">
                 <code>


### PR DESCRIPTION
## 概要
Issue #113 の対応として、スプレッド演算子を使用したプロパティのサポート状態に関するUIテキストを更新しました。

## 修正内容
- スプレッド演算子のサポートに関する説明テキストを更新し、現在はサポート済みであることを明示
- スプレッド演算子の例の見出しの色を赤から緑に変更し、サポート状態を視覚的に示すように修正
- 「false positive」という表記を「now supported」に変更

## スクリーンショット
なし（テキスト表示の更新のみ）

## 関連Issue
Closes #113

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1750732435028579 -->